### PR TITLE
添加自带mongodb的镜像

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,12 @@
+SBDoc Docker 镜像
+===
+
+自带mongodb镜像
+---
+
+参见：[sbdoc-with-mongo/README.md](./sbdoc-with-mongo/README.md)
+
+无mongodb镜像
+---
+
+come soon...

--- a/docker/sbdoc-with-mongo/Dockerfile
+++ b/docker/sbdoc-with-mongo/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:6.10.3
+MAINTAINER pollyduan pollyduan@163.com
+
+RUN apt-get update \
+  && apt-get install -yqq supervisor mongodb \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /var/log/supervisor
+
+RUN git clone https://github.com/sx1989827/SBDoc.git /root/SBDoc
+
+RUN mkdir -p /data/db
+
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+EXPOSE 10000
+
+ENTRYPOINT "/usr/bin/supervisord"

--- a/docker/sbdoc-with-mongo/README.md
+++ b/docker/sbdoc-with-mongo/README.md
@@ -1,0 +1,41 @@
+SBDoc Docker 镜像
+===
+
+构建镜像
+---
+
+使用docker命令构建
+
+```
+docker build -t sx1989827/sbdoc .
+```
+
+启动容器
+---
+
+```
+docker run -d --name sbdoc -p 10000:10000 sx1989827/sbdoc
+```
+
+稍等片刻，系统需要加载配置。
+
+```
+http://127.0.0.1:10000/
+```
+
+docker-compose用户
+---
+
+如果你安装了docker-compose：
+
+### 构建镜像
+
+```
+docker-compose build
+```
+
+### 启动容器
+
+```
+docker-compose up -d
+```

--- a/docker/sbdoc-with-mongo/docker-compose.yml
+++ b/docker/sbdoc-with-mongo/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "2"
+services:
+  sbdoc:
+    image: sx1989827/sbdoc
+    build: "."
+    container_name: "sbdoc"
+    ports:
+      - 10000:10000

--- a/docker/sbdoc-with-mongo/supervisord.conf
+++ b/docker/sbdoc-with-mongo/supervisord.conf
@@ -1,0 +1,8 @@
+[supervisord]
+nodaemon=true
+
+[program:mongodb]
+command=/usr/bin/mongod
+
+[program:sbdoc]
+command=/usr/local/bin/node /root/SBDoc/SBDoc/bin/www


### PR DESCRIPTION
使用node官方镜像，tag ： 6.10.3
apt-get安装了supervisord作为服务管理；
使用git clone了最新版本的SBDoc；