### PR TITLE
增加docker构建文件

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,19 @@
 SBDoc Docker 镜像
 ===
 
-自带mongodb镜像
+自带mongodb镜像-debian
 ---
 
 参见：[sbdoc-with-mongo/README.md](./sbdoc-with-mongo/README.md)
+
+此版本使用alpine，构建后镜像为 1 GB。
+
+自带mongodb镜像-alpine
+---
+
+参见：[sbdoc-with-mongo-alpine/README.md](./sbdoc-with-mongo-alpine/README.md)
+
+此版本使用alpine，构建后镜像为 340 MB。
 
 无mongodb镜像
 ---

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,12 @@
+SBDoc Docker 镜像
+===
+
+自带mongodb镜像
+---
+
+参见：[sbdoc-with-mongo/README.md](./sbdoc-with-mongo/README.md)
+
+无mongodb镜像
+---
+
+come soon...

--- a/docker/sbdoc-with-mongo-alpine/Dockerfile
+++ b/docker/sbdoc-with-mongo-alpine/Dockerfile
@@ -1,0 +1,20 @@
+FROM mvertes/alpine-mongo:3.4.4-0
+MAINTAINER pollyduan pollyduan@163.com
+
+RUN echo '@edge http://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories
+RUN echo '@edge http://dl-3.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
+
+RUN apk update && apk upgrade \
+  && apk add --no-cache nodejs-lts@edge supervisor git\
+  && rm -rf /tmp/* && rm -rf /root/.npm/*
+
+RUN mkdir -p /var/log/supervisor
+
+RUN git clone https://github.com/sx1989827/SBDoc.git /root/SBDoc
+
+RUN mkdir -p /data/db
+
+COPY supervisord.conf /etc/supervisor.d/supervisord.ini
+EXPOSE 10000
+
+ENTRYPOINT "/usr/bin/supervisord"

--- a/docker/sbdoc-with-mongo-alpine/README.md
+++ b/docker/sbdoc-with-mongo-alpine/README.md
@@ -1,0 +1,41 @@
+SBDoc Docker 镜像
+===
+
+构建镜像
+---
+
+使用docker命令构建
+
+```
+docker build -t sx1989827/sbdoc-alpine .
+```
+
+启动容器
+---
+
+```
+docker run -d --name sbdoc -p 10000:10000 sx1989827/sbdoc-alpine
+```
+
+稍等片刻，系统需要加载配置。
+
+```
+http://127.0.0.1:10000/
+```
+
+docker-compose用户
+---
+
+如果你安装了docker-compose：
+
+### 构建镜像
+
+```
+docker-compose build
+```
+
+### 启动容器
+
+```
+docker-compose up -d
+```

--- a/docker/sbdoc-with-mongo-alpine/docker-compose.yml
+++ b/docker/sbdoc-with-mongo-alpine/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "2"
+services:
+  sbdoc:
+    image: sx1989827/sbdoc-alpine
+    build: "."
+    container_name: "sbdoc"
+    ports:
+      - 10000:10000

--- a/docker/sbdoc-with-mongo-alpine/supervisord.conf
+++ b/docker/sbdoc-with-mongo-alpine/supervisord.conf
@@ -1,0 +1,8 @@
+[supervisord]
+nodaemon=true
+
+[program:mongodb]
+command=/usr/bin/mongod
+
+[program:sbdoc]
+command=/usr/bin/node /root/SBDoc/SBDoc/bin/www

--- a/docker/sbdoc-with-mongo/Dockerfile
+++ b/docker/sbdoc-with-mongo/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:6.10.3
+MAINTAINER pollyduan pollyduan@163.com
+
+RUN apt-get update \
+  && apt-get install -yqq supervisor mongodb \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /var/log/supervisor
+
+RUN git clone https://github.com/sx1989827/SBDoc.git /root/SBDoc
+
+RUN mkdir -p /data/db
+
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+EXPOSE 10000
+
+ENTRYPOINT "/usr/bin/supervisord"

--- a/docker/sbdoc-with-mongo/README.md
+++ b/docker/sbdoc-with-mongo/README.md
@@ -1,0 +1,41 @@
+SBDoc Docker 镜像
+===
+
+构建镜像
+---
+
+使用docker命令构建
+
+```
+docker build -t sx1989827/sbdoc .
+```
+
+启动容器
+---
+
+```
+docker run -d --name sbdoc -p 10000:10000 sx1989827/sbdoc
+```
+
+稍等片刻，系统需要加载配置。
+
+```
+http://127.0.0.1:10000/
+```
+
+docker-compose用户
+---
+
+如果你安装了docker-compose：
+
+### 构建镜像
+
+```
+docker-compose build
+```
+
+### 启动容器
+
+```
+docker-compose up -d
+```

--- a/docker/sbdoc-with-mongo/docker-compose.yml
+++ b/docker/sbdoc-with-mongo/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "2"
+services:
+  sbdoc:
+    image: sx1989827/sbdoc
+    build: "."
+    container_name: "sbdoc"
+    ports:
+      - 10000:10000

--- a/docker/sbdoc-with-mongo/supervisord.conf
+++ b/docker/sbdoc-with-mongo/supervisord.conf
@@ -1,0 +1,8 @@
+[supervisord]
+nodaemon=true
+
+[program:mongodb]
+command=/usr/bin/mongod
+
+[program:sbdoc]
+command=/usr/local/bin/node /root/SBDoc/SBDoc/bin/www


### PR DESCRIPTION
增加两个版本的构建，分别采用：
node 6.10.3官方镜像，base镜像为debian；构建最终镜像1G，但用户较熟悉，便于二次包装。
另一个版本采用alpine，初始安装node 6.10.3，构建最终镜像340M，便于用户体验，生产环境慎用。

除了基础镜像之外，采用supervisord进行服务管理，内置mongodb。